### PR TITLE
fix StopIteration exception and getting payments as dataframe function

### DIFF
--- a/bunqexport/export.py
+++ b/bunqexport/export.py
@@ -86,7 +86,7 @@ class Payments():
         self.payments['created'] = pandas.to_datetime(self.payments['created'])
         self.payments['updated'] = pandas.to_datetime(self.payments['updated'])
         self.payments['description'] = \
-            self.payments['description'].str.replace('\\n', ' ')
+            self.payments['description'].str.replace(r'\n', ' ')
 
     def __repr__(self):
         return self.payments.to_string(

--- a/bunqexport/export.py
+++ b/bunqexport/export.py
@@ -66,7 +66,12 @@ def _iter_all_payments(account_id, count=200):
 def _get_all_payments(count, account_id=None):
     """Fetch all Payments wie bunq api in bunq_sdk format"""
     payments_gen = _iter_all_payments(account_id, 200)
-    result = [next(payments_gen) for _ in range(count)]
+    result = []
+    for _ in range(count):
+        try:
+            result.append(next(payments_gen))
+        except StopIteration:
+            break
     return result
 
 

--- a/bunqexport/export.py
+++ b/bunqexport/export.py
@@ -10,7 +10,6 @@ every active account.
 """
 
 import argparse
-import io
 import json
 import logging
 import sys
@@ -105,14 +104,13 @@ class Payments():
                 'description': lambda x: x.replace('\n', ' ').strip(),
             })
 
-    def to_csv(self, path, mode=None):
+    def to_csv(self, path_or_buf, mode=None):
         """Create a csv export from bunq data"""
-        with io.open(path, 'w', encoding='utf-8') as buf:
-            self.payments.to_csv(
-                buf,
-                date_format='%d.%m.%Y' if mode == 'lexware' else None,
-                index=False,
-                line_terminator='\n' if sys.platform == 'win32' else '\r\n')
+        self.payments.to_csv(
+            path_or_buf,
+            date_format='%d.%m.%Y' if mode == 'lexware' else None,
+            index=False,
+            line_terminator='\n' if sys.platform == 'win32' else '\r\n')
 
     def to_json(self, path_or_buf):
         """Create a json export from flattened (depth=1) bunq data"""

--- a/bunqexport/export.py
+++ b/bunqexport/export.py
@@ -181,10 +181,12 @@ def payments_as_dataframe(
     """Fetch payments from all accounts as pandas.DataFrame."""
     _setup_context(conf)
     accounts = Accounts()
-    dfs = [
-        Payments.fetch_account(account_id, payments_per_account).payments
-        for account_id, account_name in accounts.ids()
-    ]
+    dfs = []
+    for account_id, account_name in accounts.ids():
+        df_of_account = Payments.fetch_account(
+            account_id, payments_per_account).payments
+        df_of_account['account_name'] = account_name
+        dfs.append(df_of_account)
     combined_df = pandas.concat(dfs)
     for col in ('amount.value', 'balance_after_mutation.value'):
         combined_df[col] = combined_df[col].astype(float)

--- a/bunqexport/export.py
+++ b/bunqexport/export.py
@@ -121,6 +121,14 @@ class Payments():
     def __len__(self):
         return len(self.payments)
 
+    @classmethod
+    def fetch_account(cls, account_id, count):
+        """Fetch 'count' payments from 'account_id'."""
+        payments = _get_all_payments(count, account_id)
+        payments_as_json = (p.to_json() for p in reversed(payments))
+        data = '[' + ','.join(payments_as_json) + ']'
+        return Payments(data)
+
 
 class Accounts():  # pylint: disable=too-few-public-methods
     """
@@ -193,10 +201,7 @@ def main():
     accounts = Accounts()
 
     for account_id, account_name in accounts.ids():
-        payments = _get_all_payments(args.payments, account_id)
-        payments_as_json = (p.to_json() for p in reversed(payments))
-        data = '[' + ','.join(payments_as_json) + ']'
-        payments = Payments(data)
+        payments = Payments.fetch_account(account_id, args.payments)
         _export(args.outfile, payments, user, account_name, args.mode)
         print(payments)
 

--- a/bunqexport/export.py
+++ b/bunqexport/export.py
@@ -186,6 +186,8 @@ def payments_as_dataframe(
         for account_id, account_name in accounts.ids()
     ]
     combined_df = pandas.concat(dfs)
+    for col in ('amount.value', 'balance_after_mutation.value'):
+        combined_df[col] = combined_df[col].astype(float)
     return combined_df.sort_values('created', ascending=False)
 
 

--- a/bunqexport/tests/test_exports.py
+++ b/bunqexport/tests/test_exports.py
@@ -147,7 +147,7 @@ class TestPayments(unittest.TestCase):
         self.assertEqual(fobj.getvalue(),
                          'allow_chat,attachment,created,description,id,monetary_account_id,request_reference_split_the_bill,sub_type,type,updated,alias.name,alias.type,alias.value,amount.currency,amount.value,balance_after_mutation.currency,balance_after_mutation.value,counterparty_alias.name,counterparty_alias.type,counterparty_alias.value\r\n'
                          'False,[],23.12.2019,bunq account top up,232997638,1111111,[],PAYMENT,CHECKOUT_MERCHANT,23.12.2019,Felix Mustermann,IBAN,NL94BUNQXXXXXXXXX,EUR,200.00,EUR,200.00,bunq,IBAN,NL61BUNQYYYYYYYYYY\r\n'
-                         'False,[],23.12.2019,"Some Company\n",233385317,1111111,[],PAYMENT,MASTERCARD,24.12.2019,Felix Mustermann,IBAN,NL94BUNQXXXXXXXXX,EUR,-16.96,EUR,183.04,Thank You,IBAN,\r\n'
+                         'False,[],23.12.2019,Some Company ,233385317,1111111,[],PAYMENT,MASTERCARD,24.12.2019,Felix Mustermann,IBAN,NL94BUNQXXXXXXXXX,EUR,-16.96,EUR,183.04,Thank You,IBAN,\r\n'
                          'False,[],23.12.2019,,233385323,1111111,[],PAYMENT,SAVINGS,23.12.2019,Felix Mustermann,IBAN,NL94BUNQXXXXXXXXX,EUR,-0.04,EUR,183.00,Felix Mustermann,IBAN,NL45BUNQZZZZZZZZZZ\r\n'
                          'False,[],24.12.2019,---,233569632,1111111,[],SCT,EBA_SCT,24.12.2019,Felix Mustermann,IBAN,NL94BUNQXXXXXXXXX,EUR,500.00,EUR,683.00,Felix Mustermann,IBAN,DE831111111222222222222\r\n')
 
@@ -157,7 +157,7 @@ class TestPayments(unittest.TestCase):
         self.assertEqual(fobj.getvalue(),
                          'allow_chat,attachment,created,description,id,monetary_account_id,request_reference_split_the_bill,sub_type,type,updated,alias.name,alias.type,alias.value,amount.currency,amount.value,balance_after_mutation.currency,balance_after_mutation.value,counterparty_alias.name,counterparty_alias.type,counterparty_alias.value\r\n'
                          'False,[],2019-12-23 09:56:48.004134,bunq account top up,232997638,1111111,[],PAYMENT,CHECKOUT_MERCHANT,2019-12-23 09:56:48.004134,Felix Mustermann,IBAN,NL94BUNQXXXXXXXXX,EUR,200.00,EUR,200.00,bunq,IBAN,NL61BUNQYYYYYYYYYY\r\n'
-                         'False,[],2019-12-23 17:31:34.703966,"Some Company\n",233385317,1111111,[],PAYMENT,MASTERCARD,2019-12-24 09:36:26.128422,Felix Mustermann,IBAN,NL94BUNQXXXXXXXXX,EUR,-16.96,EUR,183.04,Thank You,IBAN,\r\n'
+                         'False,[],2019-12-23 17:31:34.703966,Some Company ,233385317,1111111,[],PAYMENT,MASTERCARD,2019-12-24 09:36:26.128422,Felix Mustermann,IBAN,NL94BUNQXXXXXXXXX,EUR,-16.96,EUR,183.04,Thank You,IBAN,\r\n'
                          'False,[],2019-12-23 17:31:34.856484,,233385323,1111111,[],PAYMENT,SAVINGS,2019-12-23 17:31:34.856484,Felix Mustermann,IBAN,NL94BUNQXXXXXXXXX,EUR,-0.04,EUR,183.00,Felix Mustermann,IBAN,NL45BUNQZZZZZZZZZZ\r\n'
                          'False,[],2019-12-24 07:00:46.074516,---,233569632,1111111,[],SCT,EBA_SCT,2019-12-24 07:00:46.074516,Felix Mustermann,IBAN,NL94BUNQXXXXXXXXX,EUR,500.00,EUR,683.00,Felix Mustermann,IBAN,DE831111111222222222222\r\n')
 
@@ -193,7 +193,7 @@ class TestPayments(unittest.TestCase):
     "allow_chat": false,
     "attachment": [],
     "created": "2019-12-23T17:31:34.703Z",
-    "description": "Some Company\n",
+    "description": "Some Company ",
     "id": 233385317,
     "monetary_account_id": 1111111,
     "request_reference_split_the_bill": [],
@@ -259,11 +259,12 @@ class TestPayments(unittest.TestCase):
 
     def test_repr(self):
         self.assertEqual([l.rstrip() for l in str(self.payments).split('\n')],
-                         ['created    type               counterparty_alias.name amount.currency amount.value description',
-                          '23.12.2019  CHECKOUT_MERCHANT              bunq        EUR             200.00       bunq account top up',
-                          '23.12.2019         MASTERCARD         Thank You        EUR             -16.96              Some Company',
-                          '23.12.2019            SAVINGS  Felix Mustermann        EUR              -0.04',
-                          '24.12.2019            EBA_SCT  Felix Mustermann        EUR             500.00                       ---'])
+                         ['created    type              counterparty_alias.name amount.currency amount.value description',
+                          '23.12.2019 CHECKOUT_MERCHANT             bunq        EUR             200.00       bunq account top up',
+                          '23.12.2019        MASTERCARD        Thank You        EUR             -16.96              Some Company',
+                          '23.12.2019           SAVINGS Felix Mustermann        EUR              -0.04',
+                          '24.12.2019           EBA_SCT Felix Mustermann        EUR             500.00                       ---']
+                         )
 
     def test_len(self):
         self.assertEqual(len(self.payments),


### PR DESCRIPTION
- handle StopIteration for when count is larger than number of transactions
- add `Payments.fetch_account` classmethod
- add `payments_as_dataframe` function