### PR TITLE
add option to amend previously fetched data instead of redownloading all data

### DIFF
--- a/bunqexport/export.py
+++ b/bunqexport/export.py
@@ -221,15 +221,19 @@ def _export(fname, payments, user, account_name, mode):
 
 def payments_as_dataframe(
     conf: str = "bunq-sandbox.conf",
-    payments_per_account: int = 200,
+    payments_per_account: Optional[int] = None,
     df_old: Optional[pandas.DataFrame] = None,
 ):
     """Fetch payments from all accounts as pandas.DataFrame.
+
+    If payments_per_account not provided, all payments will be downloaded.
 
     Optionally pass an incomplete pandas.DataFrame to `df_old` such that
     existing data isn't downloaded again."""
     _setup_context(conf)
     accounts = Accounts()
+    if payments_per_account is None:
+        payments_per_account = sys.maxsize
     dfs = [] if df_old is None else [df_old]
     for account_id, account_name in accounts.ids():
         if df_old is not None:


### PR DESCRIPTION
This allows one to do:
```python
df_old = pd.read_pickle("all_payments.pickle")

df_all = payments_as_dataframe("bunq-production.conf", 20_000, df_old)
df_all.to_pickle("all_payments.pickle")
```

It significantly speeds up my payments analysis tools because I do not have to redownload all previously fetched data.