### PR TITLE
remove prettier

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,10 +9,6 @@ repos:
       - id: check-added-large-files
       - id: fix-encoding-pragma
       - id: mixed-line-ending
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v2.2.1
-    hooks:
-      - id: prettier
   - repo: https://github.com/timothycrosley/isort
     rev: 5.6.4
     hooks:


### PR DESCRIPTION
I believe this doesn't do anything for Python code. It also requires one to install `node` to just run these filters (which on my Mac failed).